### PR TITLE
Tuned defaults to significant values

### DIFF
--- a/src/components/sorting/audio_controls.rs
+++ b/src/components/sorting/audio_controls.rs
@@ -19,8 +19,8 @@ impl Default for AudioConfig {
         Self {
             enabled: true,
             sound_type: OscillatorType::Sine,
-            min_frequency: 50.0,
-            max_frequency: 800.0,
+            min_frequency: 55.0, // A1 in standard tuning
+            max_frequency: 880.0, // A5 in standard tuning
             note_duration: Duration::from_millis(200),
         }
     }

--- a/src/pages/sorting.rs
+++ b/src/pages/sorting.rs
@@ -119,7 +119,7 @@ pub struct SortConfig {
 impl Default for SortConfig {
     fn default() -> Self {
         Self {
-            input_len: 100,
+            input_len: 96, // LCM of 12 & 32; useful for pitch and computation
             sorting_algorithm: SortingAlgorithm::default(),
             audio_enabled: true,
             playback_time: 10.0,


### PR DESCRIPTION
Tuned default frequencies to 55hz and 880hz, A notes in ISO 16 standard tuning. The default input_len has also been changed to 96. Factors of 12 are useful when mapping pitch as their are 12 tones in a standard octave. Factors of 32 are useful when dealing with algorithms and computation. 96 is the least common multiple of these two integers. If the pitches are subdivided evenly along the log scale, the resulting subdivisions of the four octave range from 55hz to 880hz and 96 corresponds perfectly to the chromatic notes from A1-A5 in just intonation. There may be more work to be done.